### PR TITLE
Scanlab SMC Driver: Implements loading RTC6 PCIe Firmware

### DIFF
--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcconfiguration.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcconfiguration.cpp
@@ -255,6 +255,8 @@ void CSMCConfiguration::SetFirmwareResources(const std::string& sFirmwareDataRes
     if (sFirmwareDataResource.empty())
         throw ELibMCDriver_ScanLabSMCInterfaceException(LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCFIRMWARERESOURCENAME);
 
+    m_sFirmwareDataResource = sFirmwareDataResource;
+
     if (m_pDriverEnvironment->MachineHasResourceData(sFirmwareDataResource)) {
         m_pDriverEnvironment->RetrieveMachineResourceData(sFirmwareDataResource, m_FirmwareData);
     }
@@ -316,7 +318,7 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
     newCorrectionFile = pWorkingDirectory->StoreCustomDataInTempFile("ct5", m_CorrectionFileData);
 
     pWorkingDirectory->StoreCustomData("RTC6RBF.rbf", m_FPGAData);
-    pWorkingDirectory->StoreCustomData("RTC6ETH.out", m_FirmwareData);
+    pWorkingDirectory->StoreCustomData(m_sFirmwareDataResource + ".out", m_FirmwareData);
     pWorkingDirectory->StoreCustomData("RTC6DAT.dat", m_AuxiliaryData);
 
     std::string sBaseDirectoryPath = pWorkingDirectory->GetAbsoluteFilePath();
@@ -389,6 +391,7 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
             nodesToCopyFromTemplate.push_back("KinematicsList");
             nodesToCopyFromTemplate.push_back("LaserConfig");
             nodesToCopyFromTemplate.push_back("IOConfig");
+            nodesToCopyFromTemplate.push_back("SystemConfig");
 
             break;
         default:

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcconfiguration.hpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcconfiguration.hpp
@@ -66,7 +66,10 @@ private:
     
     uint32_t m_nSerialNumber;
     std::vector<uint8_t> m_CorrectionFileData;
+    
+    std::string m_sFirmwareDataResource;
     std::vector<uint8_t> m_FirmwareData;
+
     std::vector<uint8_t> m_FPGAData;
     std::vector<uint8_t> m_AuxiliaryData;
     std::string m_sIPAddress;


### PR DESCRIPTION
* Implements RTC6 PCIe firmware loading if the RTC6 Ethernet IP Address is not specified in the configuration file.
* Implements copying of the <SystemConfig> xml node of the configuration file.