### PR TITLE
Scanlab SMC Driver: Refactored CSMCJobInstance::ReadSimulationFile to…

### DIFF
--- a/Drivers/ScanLabSMC/ACT/LibMCDriver_ScanLabSMC.xml
+++ b/Drivers/ScanLabSMC/ACT/LibMCDriver_ScanLabSMC.xml
@@ -103,7 +103,7 @@
 		<error name="EMPTYRTCSERVICEDLLRESOURCENAME" code="1049" description="Empty RTC Service DLL Resource Name." />
 		<error name="RTCSERVICERESOURCENOTFOUND" code="1050" description="RTC Service Resource not found." />
 		<error name="EMPTYRTCSERVICEDLLRESOURCEDATA" code="1051" description="Empty RTC Service DLL Resource Data." />		
-											
+		<error name="SIMULATIONDATALOADINGISNOTSUPPORTED" code="1052" description="Simulation data loading is not supported for this version." />		
 	</errors>
 
 	<struct name="Point2D">
@@ -325,14 +325,6 @@ Custom implementation
 
 		<method name="LoadSimulationData" description="Reads the SMC Simulation data into a data table.">
 			<param name="SimulationDataTable" type="class" class="LibMCEnv:DataTable" pass="in" description="Data table object to read the simulation into." />
-		</method>	
-
-		<method name="LoadSimulationData_SMC_v1" description="Reads the SMC Simulation data into a data table.">
-			<param name="SimulationDataTable" type="class" class="LibMCEnv:DataTable" pass="in" description="Data table object to read the simulation into." />
-		</method>	
-
-		<method name="LoadLogRecordData" description="Reads the SMC Log Record data into a data table.">
-			<param name="LogRecordDataTable" type="class" class="LibMCEnv:DataTable" pass="in" description="Data table object to read the simulation into." />
 		</method>	
 		
 		<method name="GetJobCharacteristic" description="Returns a characteristic value of a job.">

--- a/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_dynamic.h
+++ b/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_dynamic.h
@@ -253,24 +253,6 @@ typedef LibMCDriver_ScanLabSMCResult (*PLibMCDriver_ScanLabSMCSMCJob_StopExecuti
 typedef LibMCDriver_ScanLabSMCResult (*PLibMCDriver_ScanLabSMCSMCJob_LoadSimulationDataPtr) (LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pSimulationDataTable);
 
 /**
-* Reads the SMC Simulation data into a data table.
-*
-* @param[in] pSMCJob - SMCJob instance.
-* @param[in] pSimulationDataTable - Data table object to read the simulation into.
-* @return error code or 0 (success)
-*/
-typedef LibMCDriver_ScanLabSMCResult (*PLibMCDriver_ScanLabSMCSMCJob_LoadSimulationData_SMC_v1Ptr) (LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pSimulationDataTable);
-
-/**
-* Reads the SMC Log Record data into a data table.
-*
-* @param[in] pSMCJob - SMCJob instance.
-* @param[in] pLogRecordDataTable - Data table object to read the simulation into.
-* @return error code or 0 (success)
-*/
-typedef LibMCDriver_ScanLabSMCResult (*PLibMCDriver_ScanLabSMCSMCJob_LoadLogRecordDataPtr) (LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pLogRecordDataTable);
-
-/**
 * Returns a characteristic value of a job.
 *
 * @param[in] pSMCJob - SMCJob instance.
@@ -874,8 +856,6 @@ typedef struct {
 	PLibMCDriver_ScanLabSMCSMCJob_WaitForExecutionPtr m_SMCJob_WaitForExecution;
 	PLibMCDriver_ScanLabSMCSMCJob_StopExecutionPtr m_SMCJob_StopExecution;
 	PLibMCDriver_ScanLabSMCSMCJob_LoadSimulationDataPtr m_SMCJob_LoadSimulationData;
-	PLibMCDriver_ScanLabSMCSMCJob_LoadSimulationData_SMC_v1Ptr m_SMCJob_LoadSimulationData_SMC_v1;
-	PLibMCDriver_ScanLabSMCSMCJob_LoadLogRecordDataPtr m_SMCJob_LoadLogRecordData;
 	PLibMCDriver_ScanLabSMCSMCJob_GetJobCharacteristicPtr m_SMCJob_GetJobCharacteristic;
 	PLibMCDriver_ScanLabSMCSMCJob_GetJobDurationPtr m_SMCJob_GetJobDuration;
 	PLibMCDriver_ScanLabSMCSMCConfiguration_SetDynamicViolationReactionPtr m_SMCConfiguration_SetDynamicViolationReaction;

--- a/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_dynamic.hpp
+++ b/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_dynamic.hpp
@@ -239,6 +239,7 @@ public:
 			case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCENAME: return "EMPTYRTCSERVICEDLLRESOURCENAME";
 			case LIBMCDRIVER_SCANLABSMC_ERROR_RTCSERVICERESOURCENOTFOUND: return "RTCSERVICERESOURCENOTFOUND";
 			case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCEDATA: return "EMPTYRTCSERVICEDLLRESOURCEDATA";
+			case LIBMCDRIVER_SCANLABSMC_ERROR_SIMULATIONDATALOADINGISNOTSUPPORTED: return "SIMULATIONDATALOADINGISNOTSUPPORTED";
 		}
 		return "UNKNOWN";
 	}
@@ -308,6 +309,7 @@ public:
 			case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCENAME: return "Empty RTC Service DLL Resource Name.";
 			case LIBMCDRIVER_SCANLABSMC_ERROR_RTCSERVICERESOURCENOTFOUND: return "RTC Service Resource not found.";
 			case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCEDATA: return "Empty RTC Service DLL Resource Data.";
+			case LIBMCDRIVER_SCANLABSMC_ERROR_SIMULATIONDATALOADINGISNOTSUPPORTED: return "Simulation data loading is not supported for this version.";
 		}
 		return "unknown error";
 	}
@@ -544,8 +546,6 @@ public:
 	inline void WaitForExecution(const LibMCDriver_ScanLabSMC_uint32 nTimeOutInMilliseconds);
 	inline void StopExecution();
 	inline void LoadSimulationData(classParam<LibMCEnv::CDataTable> pSimulationDataTable);
-	inline void LoadSimulationData_SMC_v1(classParam<LibMCEnv::CDataTable> pSimulationDataTable);
-	inline void LoadLogRecordData(classParam<LibMCEnv::CDataTable> pLogRecordDataTable);
 	inline LibMCDriver_ScanLabSMC_double GetJobCharacteristic(const eJobCharacteristic eValueType);
 	inline LibMCDriver_ScanLabSMC_double GetJobDuration();
 };
@@ -788,8 +788,6 @@ public:
 		pWrapperTable->m_SMCJob_WaitForExecution = nullptr;
 		pWrapperTable->m_SMCJob_StopExecution = nullptr;
 		pWrapperTable->m_SMCJob_LoadSimulationData = nullptr;
-		pWrapperTable->m_SMCJob_LoadSimulationData_SMC_v1 = nullptr;
-		pWrapperTable->m_SMCJob_LoadLogRecordData = nullptr;
 		pWrapperTable->m_SMCJob_GetJobCharacteristic = nullptr;
 		pWrapperTable->m_SMCJob_GetJobDuration = nullptr;
 		pWrapperTable->m_SMCConfiguration_SetDynamicViolationReaction = nullptr;
@@ -1067,24 +1065,6 @@ public:
 		dlerror();
 		#endif // _WIN32
 		if (pWrapperTable->m_SMCJob_LoadSimulationData == nullptr)
-			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
-		
-		#ifdef _WIN32
-		pWrapperTable->m_SMCJob_LoadSimulationData_SMC_v1 = (PLibMCDriver_ScanLabSMCSMCJob_LoadSimulationData_SMC_v1Ptr) GetProcAddress(hLibrary, "libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1");
-		#else // _WIN32
-		pWrapperTable->m_SMCJob_LoadSimulationData_SMC_v1 = (PLibMCDriver_ScanLabSMCSMCJob_LoadSimulationData_SMC_v1Ptr) dlsym(hLibrary, "libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1");
-		dlerror();
-		#endif // _WIN32
-		if (pWrapperTable->m_SMCJob_LoadSimulationData_SMC_v1 == nullptr)
-			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
-		
-		#ifdef _WIN32
-		pWrapperTable->m_SMCJob_LoadLogRecordData = (PLibMCDriver_ScanLabSMCSMCJob_LoadLogRecordDataPtr) GetProcAddress(hLibrary, "libmcdriver_scanlabsmc_smcjob_loadlogrecorddata");
-		#else // _WIN32
-		pWrapperTable->m_SMCJob_LoadLogRecordData = (PLibMCDriver_ScanLabSMCSMCJob_LoadLogRecordDataPtr) dlsym(hLibrary, "libmcdriver_scanlabsmc_smcjob_loadlogrecorddata");
-		dlerror();
-		#endif // _WIN32
-		if (pWrapperTable->m_SMCJob_LoadLogRecordData == nullptr)
 			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
 		
 		#ifdef _WIN32
@@ -1701,14 +1681,6 @@ public:
 		if ( (eLookupError != 0) || (pWrapperTable->m_SMCJob_LoadSimulationData == nullptr) )
 			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
 		
-		eLookupError = (*pLookup)("libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1", (void**)&(pWrapperTable->m_SMCJob_LoadSimulationData_SMC_v1));
-		if ( (eLookupError != 0) || (pWrapperTable->m_SMCJob_LoadSimulationData_SMC_v1 == nullptr) )
-			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
-		
-		eLookupError = (*pLookup)("libmcdriver_scanlabsmc_smcjob_loadlogrecorddata", (void**)&(pWrapperTable->m_SMCJob_LoadLogRecordData));
-		if ( (eLookupError != 0) || (pWrapperTable->m_SMCJob_LoadLogRecordData == nullptr) )
-			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
-		
 		eLookupError = (*pLookup)("libmcdriver_scanlabsmc_smcjob_getjobcharacteristic", (void**)&(pWrapperTable->m_SMCJob_GetJobCharacteristic));
 		if ( (eLookupError != 0) || (pWrapperTable->m_SMCJob_GetJobCharacteristic == nullptr) )
 			return LIBMCDRIVER_SCANLABSMC_ERROR_COULDNOTFINDLIBRARYEXPORT;
@@ -2175,26 +2147,6 @@ public:
 	{
 		LibMCEnvHandle hSimulationDataTable = pSimulationDataTable.GetHandle();
 		CheckError(m_pWrapper->m_WrapperTable.m_SMCJob_LoadSimulationData(m_pHandle, hSimulationDataTable));
-	}
-	
-	/**
-	* CSMCJob::LoadSimulationData_SMC_v1 - Reads the SMC Simulation data into a data table.
-	* @param[in] pSimulationDataTable - Data table object to read the simulation into.
-	*/
-	void CSMCJob::LoadSimulationData_SMC_v1(classParam<LibMCEnv::CDataTable> pSimulationDataTable)
-	{
-		LibMCEnvHandle hSimulationDataTable = pSimulationDataTable.GetHandle();
-		CheckError(m_pWrapper->m_WrapperTable.m_SMCJob_LoadSimulationData_SMC_v1(m_pHandle, hSimulationDataTable));
-	}
-	
-	/**
-	* CSMCJob::LoadLogRecordData - Reads the SMC Log Record data into a data table.
-	* @param[in] pLogRecordDataTable - Data table object to read the simulation into.
-	*/
-	void CSMCJob::LoadLogRecordData(classParam<LibMCEnv::CDataTable> pLogRecordDataTable)
-	{
-		LibMCEnvHandle hLogRecordDataTable = pLogRecordDataTable.GetHandle();
-		CheckError(m_pWrapper->m_WrapperTable.m_SMCJob_LoadLogRecordData(m_pHandle, hLogRecordDataTable));
 	}
 	
 	/**

--- a/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_types.hpp
+++ b/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_types.hpp
@@ -157,6 +157,7 @@ typedef void * LibMCDriver_ScanLabSMC_pvoid;
 #define LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCENAME 1049 /** Empty RTC Service DLL Resource Name. */
 #define LIBMCDRIVER_SCANLABSMC_ERROR_RTCSERVICERESOURCENOTFOUND 1050 /** RTC Service Resource not found. */
 #define LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCEDATA 1051 /** Empty RTC Service DLL Resource Data. */
+#define LIBMCDRIVER_SCANLABSMC_ERROR_SIMULATIONDATALOADINGISNOTSUPPORTED 1052 /** Simulation data loading is not supported for this version. */
 
 /*************************************************************************************************************************
  Error strings for LibMCDriver_ScanLabSMC
@@ -226,6 +227,7 @@ inline const char * LIBMCDRIVER_SCANLABSMC_GETERRORSTRING (LibMCDriver_ScanLabSM
     case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCENAME: return "Empty RTC Service DLL Resource Name.";
     case LIBMCDRIVER_SCANLABSMC_ERROR_RTCSERVICERESOURCENOTFOUND: return "RTC Service Resource not found.";
     case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCEDATA: return "Empty RTC Service DLL Resource Data.";
+    case LIBMCDRIVER_SCANLABSMC_ERROR_SIMULATIONDATALOADINGISNOTSUPPORTED: return "Simulation data loading is not supported for this version.";
     default: return "unknown error";
   }
 }

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smccontextinstance.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smccontextinstance.cpp
@@ -91,8 +91,8 @@ CSMCContextInstance::CSMCContextInstance(const std::string& sContextName, ISMCCo
 	: m_pSDK (pSDK), 
 	m_pDriverEnvironment (pDriverEnvironment), 
 	m_sContextName (sContextName), 
-	m_nSerialNumber (0)
-
+	m_nSerialNumber (0),
+	m_bSendToHardware (false)
 {
 	if (pSDK.get() == nullptr)
 		throw ELibMCDriver_ScanLabSMCInterfaceException(LIBMCDRIVER_SCANLABSMC_ERROR_INVALIDPARAM);
@@ -114,6 +114,8 @@ CSMCContextInstance::CSMCContextInstance(const std::string& sContextName, ISMCCo
 	m_pWorkingDirectory = m_pDriverEnvironment->CreateWorkingDirectory ();
 
 	m_sIPAddress = pSMCConfiguration->GetIPAddress();
+
+	m_bSendToHardware = pSMCConfiguration->GetSendToHardware();
 
 	auto pCorrectionFile = m_pWorkingDirectory->StoreCustomStringInTempFile("ct5", "");
 
@@ -220,7 +222,7 @@ std::string CSMCContextInstance::GetSimulationSubDirectory()
 
 PSMCJobInstance CSMCContextInstance::BeginJob(const double dStartPositionX, const double dStartPositionY)
 {
-	return std::make_shared<CSMCJobInstance> (m_pContextHandle, dStartPositionX, dStartPositionY, m_pWorkingDirectory, m_sSimulationSubDirectory);
+	return std::make_shared<CSMCJobInstance> (m_pContextHandle, dStartPositionX, dStartPositionY, m_pWorkingDirectory, m_sSimulationSubDirectory, m_bSendToHardware);
 }
 
 PSMCJobInstance CSMCContextInstance::GetUnfinishedJob()

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smccontextinstance.hpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smccontextinstance.hpp
@@ -63,6 +63,8 @@ private:
 
 	uint32_t m_nSerialNumber;
 
+	bool m_bSendToHardware;
+
 public:
 
 	CSMCContextInstance(const std::string & sContextName, ISMCConfiguration* pSMCConfiguration, PScanLabSMCSDK pSDK, LibMCEnv::PDriverEnvironment pDriverEnvironment, const std::string & sRTCDLLDirectory);

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjob.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjob.cpp
@@ -132,16 +132,6 @@ void CSMCJob::LoadSimulationData(LibMCEnv::PDataTable pSimulationDataTable)
     m_pJobInstance->ReadSimulationFile(pSimulationDataTable);
 }
 
-void CSMCJob::LoadSimulationData_SMC_v1(LibMCEnv::PDataTable pSimulationDataTable)
-{
-    m_pJobInstance->ReadSimulationFile_SMC_v1(pSimulationDataTable);
-}
-
-void CSMCJob::LoadLogRecordData(LibMCEnv::PDataTable pLogRecordDataTable)
-{
-    m_pJobInstance->ReadLogRecordFile(pLogRecordDataTable);
-}
-
 LibMCDriver_ScanLabSMC_double CSMCJob::GetJobCharacteristic(const LibMCDriver_ScanLabSMC::eJobCharacteristic eValueType)
 {
     return m_pJobInstance->GetJobCharacteristic (eValueType);

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjob.hpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjob.hpp
@@ -96,10 +96,6 @@ public:
 
 	void LoadSimulationData(LibMCEnv::PDataTable pSimulationDataTable) override;
 
-	void LoadSimulationData_SMC_v1(LibMCEnv::PDataTable pSimulationDataTable) override;
-
-	void LoadLogRecordData(LibMCEnv::PDataTable pLogRecordDataTable) override;
-
 	LibMCDriver_ScanLabSMC_double GetJobCharacteristic(const LibMCDriver_ScanLabSMC::eJobCharacteristic eValueType) override;
 
 	LibMCDriver_ScanLabSMC_double GetJobDuration() override;

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjobinstance.hpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjobinstance.hpp
@@ -62,6 +62,8 @@ private:
 	bool m_bHasJobDuration;
 	double m_dJobDuration;
 
+	bool m_bSendToHardware;
+
 	void drawPolylineEx(slscHandle contextHandle, const uint64_t nPointsBufferSize, const LibMCDriver_ScanLabSMC::sPoint2D* pPointsBuffer, bool bIsClosed);
 	void drawHatchesEx(const LibMCDriver_ScanLabSMC_uint64 nHatchesBufferSize, const LibMCDriver_ScanLabSMC::sHatch2D* pHatchesBuffer, const LibMCDriver_ScanLabSMC_double dMarkSpeed, const LibMCDriver_ScanLabSMC_double dJumpSpeed, const LibMCDriver_ScanLabSMC_double dPower, const LibMCDriver_ScanLabSMC_double dZValue);
 	void drawHatchesExLinearPower(const LibMCDriver_ScanLabSMC_uint64 nHatchesBufferSize, const LibMCDriver_ScanLabSMC::sHatch2D* pHatchesBuffer, const LibMCDriver_ScanLabSMC_double dMarkSpeed, const LibMCDriver_ScanLabSMC_double dJumpSpeed, const LibMCDriver_ScanLabSMC_double dPower, const LibMCDriver_ScanLabSMC_double dZValue, std::vector<double>& PowerValues1, std::vector<double>& PowerValues2, double dMaxPower);
@@ -69,7 +71,7 @@ private:
 
 public:
 
-	CSMCJobInstance(PSMCContextHandle pContextHandle, double dStartPositionX, double dStartPositionY, LibMCEnv::PWorkingDirectory pWorkingDirectory, std::string sSimulationSubDirectory);
+	CSMCJobInstance(PSMCContextHandle pContextHandle, double dStartPositionX, double dStartPositionY, LibMCEnv::PWorkingDirectory pWorkingDirectory, std::string sSimulationSubDirectory, bool bSendToHardware);
 
 	virtual ~CSMCJobInstance();
 
@@ -99,16 +101,18 @@ public:
 	void AddLayerToList(LibMCEnv::PToolpathLayer pLayer);
 
 	void ReadSimulationFile(LibMCEnv::PDataTable pDataTable);
-		
-	void ReadSimulationFile_SMC_v1(LibMCEnv::PDataTable pDataTable);
-
-	void ReadLogRecordFile(LibMCEnv::PDataTable pDataTable);	
 
 	double GetJobCharacteristic(const LibMCDriver_ScanLabSMC::eJobCharacteristic eValueType);
 
 	double GetJobDuration();
 
+private:
 
+	void ReadSimulationFile_SMC_v0_8(LibMCEnv::PDataTable pDataTable);
+
+	void ReadSimulationFile_SMC_v1_0(LibMCEnv::PDataTable pDataTable);
+
+	void ReadLogRecordFile(LibMCEnv::PDataTable pDataTable);
 };
 
 typedef std::shared_ptr<CSMCJobInstance> PSMCJobInstance;

--- a/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_abi.hpp
+++ b/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_abi.hpp
@@ -266,24 +266,6 @@ LIBMCDRIVER_SCANLABSMC_DECLSPEC LibMCDriver_ScanLabSMCResult libmcdriver_scanlab
 LIBMCDRIVER_SCANLABSMC_DECLSPEC LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_loadsimulationdata(LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pSimulationDataTable);
 
 /**
-* Reads the SMC Simulation data into a data table.
-*
-* @param[in] pSMCJob - SMCJob instance.
-* @param[in] pSimulationDataTable - Data table object to read the simulation into.
-* @return error code or 0 (success)
-*/
-LIBMCDRIVER_SCANLABSMC_DECLSPEC LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1(LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pSimulationDataTable);
-
-/**
-* Reads the SMC Log Record data into a data table.
-*
-* @param[in] pSMCJob - SMCJob instance.
-* @param[in] pLogRecordDataTable - Data table object to read the simulation into.
-* @return error code or 0 (success)
-*/
-LIBMCDRIVER_SCANLABSMC_DECLSPEC LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_loadlogrecorddata(LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pLogRecordDataTable);
-
-/**
 * Returns a characteristic value of a job.
 *
 * @param[in] pSMCJob - SMCJob instance.

--- a/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_interfaces.hpp
+++ b/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_interfaces.hpp
@@ -436,18 +436,6 @@ public:
 	virtual void LoadSimulationData(LibMCEnv::PDataTable pSimulationDataTable) = 0;
 
 	/**
-	* ISMCJob::LoadSimulationData_SMC_v1 - Reads the SMC Simulation data into a data table.
-	* @param[in] pSimulationDataTable - Data table object to read the simulation into.
-	*/
-	virtual void LoadSimulationData_SMC_v1(LibMCEnv::PDataTable pSimulationDataTable) = 0;
-
-	/**
-	* ISMCJob::LoadLogRecordData - Reads the SMC Log Record data into a data table.
-	* @param[in] pLogRecordDataTable - Data table object to read the simulation into.
-	*/
-	virtual void LoadLogRecordData(LibMCEnv::PDataTable pLogRecordDataTable) = 0;
-
-	/**
 	* ISMCJob::GetJobCharacteristic - Returns a characteristic value of a job.
 	* @param[in] eValueType - Type of job
 	* @return Characteristic Value

--- a/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_interfacewrapper.cpp
+++ b/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_interfacewrapper.cpp
@@ -653,64 +653,6 @@ LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_loadsimulationdata(Li
 	}
 }
 
-LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1(LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pSimulationDataTable)
-{
-	IBase* pIBaseClass = (IBase *)pSMCJob;
-
-	try {
-		LibMCEnv::PDataTable pISimulationDataTable = std::make_shared<LibMCEnv::CDataTable>(CWrapper::sPLibMCEnvWrapper.get(), pSimulationDataTable);
-		CWrapper::sPLibMCEnvWrapper->AcquireInstance(pISimulationDataTable.get());
-		if (!pISimulationDataTable)
-			throw ELibMCDriver_ScanLabSMCInterfaceException (LIBMCDRIVER_SCANLABSMC_ERROR_INVALIDCAST);
-		
-		ISMCJob* pISMCJob = dynamic_cast<ISMCJob*>(pIBaseClass);
-		if (!pISMCJob)
-			throw ELibMCDriver_ScanLabSMCInterfaceException(LIBMCDRIVER_SCANLABSMC_ERROR_INVALIDCAST);
-		
-		pISMCJob->LoadSimulationData_SMC_v1(pISimulationDataTable);
-
-		return LIBMCDRIVER_SCANLABSMC_SUCCESS;
-	}
-	catch (ELibMCDriver_ScanLabSMCInterfaceException & Exception) {
-		return handleLibMCDriver_ScanLabSMCException(pIBaseClass, Exception);
-	}
-	catch (std::exception & StdException) {
-		return handleStdException(pIBaseClass, StdException);
-	}
-	catch (...) {
-		return handleUnhandledException(pIBaseClass);
-	}
-}
-
-LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_loadlogrecorddata(LibMCDriver_ScanLabSMC_SMCJob pSMCJob, LibMCEnv_DataTable pLogRecordDataTable)
-{
-	IBase* pIBaseClass = (IBase *)pSMCJob;
-
-	try {
-		LibMCEnv::PDataTable pILogRecordDataTable = std::make_shared<LibMCEnv::CDataTable>(CWrapper::sPLibMCEnvWrapper.get(), pLogRecordDataTable);
-		CWrapper::sPLibMCEnvWrapper->AcquireInstance(pILogRecordDataTable.get());
-		if (!pILogRecordDataTable)
-			throw ELibMCDriver_ScanLabSMCInterfaceException (LIBMCDRIVER_SCANLABSMC_ERROR_INVALIDCAST);
-		
-		ISMCJob* pISMCJob = dynamic_cast<ISMCJob*>(pIBaseClass);
-		if (!pISMCJob)
-			throw ELibMCDriver_ScanLabSMCInterfaceException(LIBMCDRIVER_SCANLABSMC_ERROR_INVALIDCAST);
-		
-		pISMCJob->LoadLogRecordData(pILogRecordDataTable);
-
-		return LIBMCDRIVER_SCANLABSMC_SUCCESS;
-	}
-	catch (ELibMCDriver_ScanLabSMCInterfaceException & Exception) {
-		return handleLibMCDriver_ScanLabSMCException(pIBaseClass, Exception);
-	}
-	catch (std::exception & StdException) {
-		return handleStdException(pIBaseClass, StdException);
-	}
-	catch (...) {
-		return handleUnhandledException(pIBaseClass);
-	}
-}
-
 LibMCDriver_ScanLabSMCResult libmcdriver_scanlabsmc_smcjob_getjobcharacteristic(LibMCDriver_ScanLabSMC_SMCJob pSMCJob, eLibMCDriver_ScanLabSMCJobCharacteristic eValueType, LibMCDriver_ScanLabSMC_double * pValue)
 {
 	IBase* pIBaseClass = (IBase *)pSMCJob;
@@ -2255,10 +2197,6 @@ LibMCDriver_ScanLabSMCResult LibMCDriver_ScanLabSMC::Impl::LibMCDriver_ScanLabSM
 		*ppProcAddress = (void*) &libmcdriver_scanlabsmc_smcjob_stopexecution;
 	if (sProcName == "libmcdriver_scanlabsmc_smcjob_loadsimulationdata") 
 		*ppProcAddress = (void*) &libmcdriver_scanlabsmc_smcjob_loadsimulationdata;
-	if (sProcName == "libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1") 
-		*ppProcAddress = (void*) &libmcdriver_scanlabsmc_smcjob_loadsimulationdata_smc_v1;
-	if (sProcName == "libmcdriver_scanlabsmc_smcjob_loadlogrecorddata") 
-		*ppProcAddress = (void*) &libmcdriver_scanlabsmc_smcjob_loadlogrecorddata;
 	if (sProcName == "libmcdriver_scanlabsmc_smcjob_getjobcharacteristic") 
 		*ppProcAddress = (void*) &libmcdriver_scanlabsmc_smcjob_getjobcharacteristic;
 	if (sProcName == "libmcdriver_scanlabsmc_smcjob_getjobduration") 

--- a/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_types.hpp
+++ b/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_types.hpp
@@ -157,6 +157,7 @@ typedef void * LibMCDriver_ScanLabSMC_pvoid;
 #define LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCENAME 1049 /** Empty RTC Service DLL Resource Name. */
 #define LIBMCDRIVER_SCANLABSMC_ERROR_RTCSERVICERESOURCENOTFOUND 1050 /** RTC Service Resource not found. */
 #define LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCEDATA 1051 /** Empty RTC Service DLL Resource Data. */
+#define LIBMCDRIVER_SCANLABSMC_ERROR_SIMULATIONDATALOADINGISNOTSUPPORTED 1052 /** Simulation data loading is not supported for this version. */
 
 /*************************************************************************************************************************
  Error strings for LibMCDriver_ScanLabSMC
@@ -226,6 +227,7 @@ inline const char * LIBMCDRIVER_SCANLABSMC_GETERRORSTRING (LibMCDriver_ScanLabSM
     case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCENAME: return "Empty RTC Service DLL Resource Name.";
     case LIBMCDRIVER_SCANLABSMC_ERROR_RTCSERVICERESOURCENOTFOUND: return "RTC Service Resource not found.";
     case LIBMCDRIVER_SCANLABSMC_ERROR_EMPTYRTCSERVICEDLLRESOURCEDATA: return "Empty RTC Service DLL Resource Data.";
+    case LIBMCDRIVER_SCANLABSMC_ERROR_SIMULATIONDATALOADINGISNOTSUPPORTED: return "Simulation data loading is not supported for this version.";
     default: return "unknown error";
   }
 }


### PR DESCRIPTION
… Support Parser Selection Based on SMC Version

* Implements logic to select the appropriate SimulationData parser dynamically based on the detected SCANmotionControl version.
* Restored the previous SMCJob interface to ensure backward compatibility with existing code.