### PR TITLE
Scanlab SMC Driver: Upgrade of the SCANmotionControl to v1.1

### DIFF
--- a/Drivers/ScanLabSMC/ACT/LibMCDriver_ScanLabSMC.xml
+++ b/Drivers/ScanLabSMC/ACT/LibMCDriver_ScanLabSMC.xml
@@ -144,6 +144,7 @@
 	   <option name="Version_0_8" value="8" />
 	   <option name="Version_0_9" value="9" />
 	   <option name="Version_1_0" value="10" />
+	   <option name="Version_1_1" value="11" />
 	</enum>
 
 	<enum name="JobCharacteristic">

--- a/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_types.hpp
+++ b/Drivers/ScanLabSMC/Headers/CppDynamic/libmcdriver_scanlabsmc_types.hpp
@@ -271,7 +271,8 @@ namespace LibMCDriver_ScanLabSMC {
     Unknown = 0,
     Version_0_8 = 8,
     Version_0_9 = 9,
-    Version_1_0 = 10
+    Version_1_0 = 10,
+    Version_1_1 = 11
   };
   
   enum class eJobCharacteristic : LibMCDriver_ScanLabSMC_int32 {

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc.cpp
@@ -87,6 +87,9 @@ IDriver * CWrapper::CreateDriver(const std::string & sName, const std::string & 
 	if (sType == "scanlab-smc-1.0")
 		return new CDriver_ScanLabSMC(sName, sType, pDriverEnvironment);
 
+	if (sType == "scanlab-smc-1.1")
+		return new CDriver_ScanLabSMC(sName, sType, pDriverEnvironment);
+
 	if (sType == "scanlab-smc-latest")
 		return new CDriver_ScanLabSMC(sName, sType, pDriverEnvironment);
 

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_driver_scanlabsmc.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_driver_scanlabsmc.cpp
@@ -246,7 +246,7 @@ void CDriver_ScanLabSMC::LoadSDK()
     if (m_SMCDLLResourceData.empty() || m_RTCDLLResourceData.empty())
         SetDLLResources(SCANLABSMC_DEFAULT_SMCDLLRESOURCENAME, SCANLABSMC_DEFAULT_RTCDLLRESOURCENAME);
 
-    if ((m_sType == "scanlab-smc-1.0" || m_sType == "scanlab-smc-latest") && m_RTCServiceDLLResourceData.empty())
+    if ((m_sType == "scanlab-smc-1.0" || m_sType == "scanlab-smc-1.1" || m_sType == "scanlab-smc-latest") && m_RTCServiceDLLResourceData.empty())
         SetRTCServiceDLLResourceName(SCANLABSMC_DEFAULT_RTCSERVICEDLLRESOURCENAME);
 
     if (m_XercesDLLResourceData.empty())
@@ -255,7 +255,7 @@ void CDriver_ScanLabSMC::LoadSDK()
     m_pSMCDLL = m_pDLLDirectory->StoreCustomData("SCANmotionControl_x64.dll", m_SMCDLLResourceData);
     m_pRTCDLL = m_pDLLDirectory->StoreCustomData("RTC6DLLx64.dll", m_RTCDLLResourceData);
     
-    if (m_sType == "scanlab-smc-1.0" || m_sType == "scanlab-smc-latest")
+    if (m_sType == "scanlab-smc-1.0" || m_sType == "scanlab-smc-1.1" || m_sType == "scanlab-smc-latest")
         m_pRTCServiceDLL = m_pDLLDirectory->StoreCustomData("RtcService_x64.dll", m_RTCServiceDLLResourceData);
 
     m_pXercesDLL = m_pDLLDirectory->StoreCustomData("xerces-c_3_2.dll", m_XercesDLLResourceData);

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcconfiguration.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcconfiguration.cpp
@@ -400,6 +400,24 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
             nodesToCopyFromTemplate.push_back("SystemConfig");
 
             break;
+        case eSMCConfigVersion::Version_1_1:
+            // Customize writing to SMC Version 1.1
+            sVersionString = "1.1";
+            sSchemaLocationString = "cfg SCANmotionControlConfig_1_1.xsd";
+            sBoardsNodeName = "BoardList";
+            if (m_bSendToHardware)
+                sSimulationMode = "Hardware";
+            else
+                sSimulationMode = "Simulation";
+
+            nodesToCopyFromTemplate.push_back("AxesList");
+            nodesToCopyFromTemplate.push_back("ScanheadList");
+            nodesToCopyFromTemplate.push_back("KinematicsList");
+            nodesToCopyFromTemplate.push_back("LaserConfig");
+            nodesToCopyFromTemplate.push_back("IOConfig");
+            nodesToCopyFromTemplate.push_back("SystemConfig");
+
+            break;
         default:
             throw ELibMCDriver_ScanLabSMCInterfaceException(LIBMCDRIVER_SCANLABSMC_ERROR_UNSUPPORTEDSMCVERSION);
     }
@@ -459,7 +477,8 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
         }
 
         case eSMCConfigVersion::Version_0_9: 
-        case eSMCConfigVersion::Version_1_0: {
+        case eSMCConfigVersion::Version_1_0: 
+        case eSMCConfigVersion::Version_1_1: {
             if (!sRTCIPAddress.empty()) {
                 auto pEthSearchNode = pRTCConfigNode->AddChild("", "EthSearch");
                 auto pIPListNode = pEthSearchNode->AddChild("", "IPList");
@@ -512,7 +531,7 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
         
     } 
 
-    if (configVersion == eSMCConfigVersion::Version_1_0) {
+    if (configVersion == eSMCConfigVersion::Version_1_0 || configVersion == eSMCConfigVersion::Version_1_1) {
         auto pKinematicsListNode = pXMLDocument->GetRootNode()->FindChild(sCfgNameSpace, "KinematicsList", true);
         auto pKinematicsListNodes = pKinematicsListNode->GetChildrenByName(sCfgNameSpace, "Kinematic");
         uint64_t nKinematicsListCount = pKinematicsListNodes->GetNodeCount();
@@ -532,14 +551,8 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
                 pPatchedCorrectionFileNode->AddAttribute("", "CalibrationFactor", "-1");
 
             }
-
-
         }
-      
-
-
     }
-
 
     // Patch Blend Mode!
     if (configVersion == eSMCConfigVersion::Version_0_8) {
@@ -551,11 +564,6 @@ std::string CSMCConfiguration::buildConfigurationXML(LibMCEnv::CWorkingDirectory
             case eBlendMode::MaxAccuracy: pBlendModeNode->SetTextContent("MaxAccuracy"); break;
             default: pBlendModeNode->SetTextContent("Deactivated");
         }
-        
-        
-        
-        
-
     }
 
     std::string sXMLString = pXMLDocument->SaveToString (true);

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smccontextinstance.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smccontextinstance.cpp
@@ -132,6 +132,7 @@ CSMCContextInstance::CSMCContextInstance(const std::string& sContextName, ISMCCo
 	else if (versionInfo.m_nMajor == 1) {
 		switch (versionInfo.m_nMinor) {
 		case 0: configVersion = eSMCConfigVersion::Version_1_0; break;
+		case 1: configVersion = eSMCConfigVersion::Version_1_1; break;
 		default:
 			throw ELibMCDriver_ScanLabSMCInterfaceException(LIBMCDRIVER_SCANLABSMC_ERROR_UNKNOWNSMCMINORVERSION, "unknown smc minor version: " + sVersionString);
 		}

--- a/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_types.hpp
+++ b/Drivers/ScanLabSMC/Interfaces/libmcdriver_scanlabsmc_types.hpp
@@ -271,7 +271,8 @@ namespace LibMCDriver_ScanLabSMC {
     Unknown = 0,
     Version_0_8 = 8,
     Version_0_9 = 9,
-    Version_1_0 = 10
+    Version_1_0 = 10,
+    Version_1_1 = 11
   };
   
   enum class eJobCharacteristic : LibMCDriver_ScanLabSMC_int32 {


### PR DESCRIPTION
* Support for SCANmotion library version v1.1 has been implemented;
* Backward compatibility with SCANmotion version v1.0 has been preserved.