### PR TITLE
Added in event parameter filter to API code.

### DIFF
--- a/Implementation/API/amc_api_handler_ui.cpp
+++ b/Implementation/API/amc_api_handler_ui.cpp
@@ -478,10 +478,16 @@ void CAPIHandler_UI::handleEventRequest(CJSONWriter& writer, const uint8_t* pBod
 	if (apiRequest.hasValue(AMC_API_KEY_UI_FORMVALUEJSON)) {
 		sFormValueJSON = apiRequest.getJSONObjectString(AMC_API_KEY_UI_FORMVALUEJSON, LIBMC_ERROR_INVALIDFORMVALUES);
 	}
+
+	std::string sEventParameterJSON;
+	if (apiRequest.hasValue(AMC_API_KEY_STATUSPARAMETERGROUP_PARAMETERS))
+	{
+		sEventParameterJSON = apiRequest.getJSONObjectString(AMC_API_KEY_STATUSPARAMETERGROUP_PARAMETERS, LIBMC_ERROR_INVALIDFORMVALUES);
+	}
 	
 	auto pUIHandler = m_pSystemState->uiHandler();
 
-	auto pEventResult = pUIHandler->handleEvent(sEventName, sSenderUUID, sFormValueJSON, "", pAuth);
+	auto pEventResult = pUIHandler->handleEvent(sEventName, sSenderUUID, sFormValueJSON, sEventParameterJSON, pAuth);
 
 	CJSONWriterArray contentUpdateNode(writer);
 


### PR DESCRIPTION
This change enables the UI state code "pUIEnvironment->GetExternalEventParameters();" and related functions to work as expected when JSON packets contain additional parameters.