### PR TITLE
LibMCCore (scanlab, libmcenv): Fix microvector delay tick conversion and implement scatterplot channel fill

### DIFF
--- a/Drivers/ScanLab/Implementation/libmcdriver_scanlab_rtccontext.cpp
+++ b/Drivers/ScanLab/Implementation/libmcdriver_scanlab_rtccontext.cpp
@@ -1114,6 +1114,15 @@ void CRTCContext::AddMarkMovement(const LibMCDriver_ScanLab_double dTargetX, con
 	m_nCurrentScanPositionY = intY;
 }
 
+int32_t CRTCContext::ConvertDelaySecondsToTicks(double delay)
+{
+	// 1 tick = 1/64 us = 1e-6 / 64 s
+	// ticks = delay / (1e-6/64) = delay * 64e6
+	const int64_t ticks = static_cast<int64_t>(std::llround(delay * 64.0e6));
+
+	// Clamp to [0 .. 32767]
+	return static_cast<int32_t>( (ticks < 0) ? 0 :	(ticks > 32767) ? 32767 : ticks );
+}
 
 void CRTCContext::AddMicrovectorMovement(const LibMCDriver_ScanLab_uint64 nMicrovectorArrayBufferSize, const LibMCDriver_ScanLab::sMicroVector* pMicrovectorArrayBuffer)
 {
@@ -1131,9 +1140,8 @@ void CRTCContext::AddMicrovectorMovement(const LibMCDriver_ScanLab_uint64 nMicro
 
 			int32_t intX = (int32_t)dX;
 			int32_t intY = (int32_t)dY;
-
-			int32_t intDelayLaserOn = (pMicroVector->m_LaserOnDelay < 0.0) ? -1 : round(pMicroVector->m_LaserOnDelay * 100000);
-			int32_t intDelayLaserOff = (pMicroVector->m_LaserOffDelay < 0.0) ? -1 : round(pMicroVector->m_LaserOffDelay * 100000);
+			int32_t intDelayLaserOn = (pMicroVector->m_LaserOnDelay < 0.0) ? -1 : ConvertDelaySecondsToTicks(pMicroVector->m_LaserOnDelay);
+			int32_t intDelayLaserOff = (pMicroVector->m_LaserOffDelay < 0.0) ? -1 : ConvertDelaySecondsToTicks(pMicroVector->m_LaserOffDelay);
 
 			m_pScanLabSDK->n_micro_vector_abs(m_CardNo, intX, intY, intDelayLaserOn, intDelayLaserOff);
 

--- a/Drivers/ScanLab/Implementation/libmcdriver_scanlab_rtccontext.hpp
+++ b/Drivers/ScanLab/Implementation/libmcdriver_scanlab_rtccontext.hpp
@@ -213,6 +213,9 @@ protected:
 	// Calls the SetTriggerX Call that is necessary for the specific OIE board
 	void callSetTriggerOIE(uint32_t nPeriod);
 
+	// Converts a delay in seconds to RTC ticks
+	int32_t ConvertDelaySecondsToTicks(double delay);
+
 public:
 
 	CRTCContext(PRTCContextOwnerData pOwnerData, uint32_t nCardNo, bool bIsNetwork, LibMCEnv::PDriverEnvironment pDriverEnvironment);

--- a/Implementation/LibMCEnv/libmcenv_datatable.cpp
+++ b/Implementation/LibMCEnv/libmcenv_datatable.cpp
@@ -841,9 +841,34 @@ public:
 
 	void fillScatterplotChannel(AMC::CScatterplot* pScatterplot, const std::string& sChannel, const std::string& sColumn, double dScaleFactor, double dOffset) override
 	{
-		throw ELibMCEnvInterfaceException(LIBMCENV_ERROR_NOTIMPLEMENTED);
-	}
+		if (pScatterplot == nullptr)
+			throw ELibMCEnvInterfaceException(LIBMCENV_ERROR_INVALIDPARAM);
 
+		auto& channelEntries = pScatterplot->getChannelEntries();
+		auto channelIter = channelEntries.find(sChannel);
+
+		if (channelIter == channelEntries.end()) {
+			channelEntries[sChannel][sColumn] = std::vector<double>();
+		}
+		else {
+			auto& columnEntries = channelIter->second;
+
+			if (columnEntries.find(sColumn) == columnEntries.end())
+				columnEntries[sColumn] = std::vector<double>();
+			else {
+				std::string sException = "The channel = " + sChannel + " with the column = " + sColumn + " already exists";
+				throw std::runtime_error(sException.c_str());
+			}
+		}
+
+		auto& vecColumn = channelEntries[sChannel][sColumn];
+
+		vecColumn.resize(m_Rows.size());
+
+		for (size_t nIndex = 0; nIndex < m_Rows.size(); nIndex++) {
+			vecColumn[nIndex] = (double)m_Rows.at(nIndex) * dScaleFactor + dOffset;
+		}
+	}
 };
 
 


### PR DESCRIPTION
Fix microvector delay tick conversion and implement scatterplot channel fill

### feat(scanlab): convert microvector laser delays using RTC tick resolution
- Added `ConvertDelaySecondsToTicks()` to convert delay seconds into RTC ticks (1 tick = 1/64 µs) and clamp to the supported range [0..32767].
- Updated `AddMicrovectorMovement()` to use the new conversion for LaserOnDelay and LaserOffDelay while preserving `-1` as the “no delay” sentinel.

### feat(libmcenv): implement scatterplot channel population from datatable
- Implemented `fillScatterplotChannel()` to populate scatterplot channel/column vectors from the datatable rows with scale and offset applied.
- Added basic validation and guarded channel/column creation to avoid duplicate entries.