### PR TITLE
LibMCCore/Drivers (Scanlab/ScanlabSmC) : Apply laser power for microvectors and enable per-hatch power via para_line

### DIFF
--- a/Drivers/ScanLab/Implementation/libmcdriver_scanlab_rtccontext.cpp
+++ b/Drivers/ScanLab/Implementation/libmcdriver_scanlab_rtccontext.cpp
@@ -1143,6 +1143,8 @@ void CRTCContext::AddMicrovectorMovement(const LibMCDriver_ScanLab_uint64 nMicro
 			int32_t intDelayLaserOn = (pMicroVector->m_LaserOnDelay < 0.0) ? -1 : ConvertDelaySecondsToTicks(pMicroVector->m_LaserOnDelay);
 			int32_t intDelayLaserOff = (pMicroVector->m_LaserOffDelay < 0.0) ? -1 : ConvertDelaySecondsToTicks(pMicroVector->m_LaserOffDelay);
 
+			writePower(pMicroVector->m_LaserPowerInPercent, false);
+
 			m_pScanLabSDK->n_micro_vector_abs(m_CardNo, intX, intY, intDelayLaserOn, intDelayLaserOff);
 
 			m_nCurrentScanPositionX = intX;

--- a/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjobinstance.cpp
+++ b/Drivers/ScanLabSMC/Implementation/libmcdriver_scanlabsmc_smcjobinstance.cpp
@@ -247,7 +247,6 @@ void CSMCJobInstance::drawHatchesEx(const LibMCDriver_ScanLabSMC_uint64 nHatches
 
         m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_set_jump_speed(contextHandle, dJumpSpeed));
         m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_set_mark_speed(contextHandle, dMarkSpeed));
-        m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_write_analog_x(contextHandle, slsc_AnalogOutput::slsc_AnalogOutput_1, dPowerFactor, 0.0));
 
         for (uint64_t nHatchIndex = 0; nHatchIndex < nHatchesBufferSize; nHatchIndex++) {
             auto& hatch = pHatchesBuffer[nHatchIndex];
@@ -260,14 +259,13 @@ void CSMCJobInstance::drawHatchesEx(const LibMCDriver_ScanLabSMC_uint64 nHatches
             point2[0] = hatch.m_X2;
             point2[1] = hatch.m_Y2;
             point2[2] = 0.0;
-
+                        
+            std::array<double, 1> paraPower;
+            paraPower[0] = dPowerFactor;
 
             m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_jump(contextHandle, point1.data()));
-            m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_line(contextHandle, point2.data()));
-
-            //m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_para_enable(contextHandle, paraPower.data()));
-            //m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_para_line(contextHandle, point2.data(), paraPower.data()));
-
+            m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_para_enable(contextHandle, paraPower.data()));
+            m_pSDK->checkError(contextHandle, m_pSDK->slsc_job_para_line(contextHandle, point2.data(), paraPower.data()));
         }
     }
 


### PR DESCRIPTION
Apply laser power for microvectors and enable per-hatch power via para_line

### feat(scanlab/rtc): write laser power before microvector execution
- Added a `writePower(...)` call in `CRTCContext::AddMicrovectorMovement` to apply `m_LaserPowerInPercent` before issuing `n_micro_vector_abs(...)`.
- Ensures microvector replay uses the intended power level per movement segment.

### feat(scanlabsmc): switch hatch drawing to parameterized power lines
- Removed per-job analog output write (`slsc_job_write_analog_x`) from `drawHatchesEx`.
- Introduced per-hatch power parameterization using:
  - `slsc_job_para_enable(...)`
  - `slsc_job_para_line(..., paraPower)`
- Uses `dPowerFactor` as the parameter value for each hatch line, enabling power to be controlled consistently via the SMC parameterized line API.

This change aligns RTC microvector execution and SMC hatch generation with explicit laser power handling, improving consistency of power application across scan paths.