### PR TITLE
Fix the parameter override feature to accept non-string values

### DIFF
--- a/Implementation/LibMC/libmc_mccontext.cpp
+++ b/Implementation/LibMC/libmc_mccontext.cpp
@@ -309,8 +309,27 @@ void CMCContext::SetParameterOverride(const std::string& sParameterPath, const s
     pStateMachineData->extractParameterDetailsFromDotString(sParameterPath, sParameterInstance, sParameterGroup, sParameterName, false, false);
 
     auto pParameterInstanceHandler = pStateMachineData->getParameterHandler(sParameterInstance);
-    auto pParamaterGroup = pParameterInstanceHandler->findGroup(sParameterGroup, true);
-	pParamaterGroup->setParameterValueByName(sParameterName, sParameterValue);
+    auto pParameterGroup = pParameterInstanceHandler->findGroup(sParameterGroup, true);
+
+    auto eDataType = pParameterGroup->getParameterDataTypeByName(sParameterName);
+
+    switch (eDataType) {
+    case AMC::eParameterDataType::String:
+    case AMC::eParameterDataType::UUID:
+        pParameterGroup->setParameterValueByName(sParameterName, sParameterValue);
+        break;
+    case AMC::eParameterDataType::Integer:
+        pParameterGroup->setIntParameterValueByName(sParameterName, AMCCommon::CUtils::stringToInteger(sParameterValue));
+        break;
+    case AMC::eParameterDataType::Double:
+        pParameterGroup->setDoubleParameterValueByName(sParameterName, AMCCommon::CUtils::stringToDouble(sParameterValue));
+        break;
+    case AMC::eParameterDataType::Bool:
+        pParameterGroup->setBoolParameterValueByName(sParameterName, AMCCommon::CUtils::stringToBool(sParameterValue));
+        break;
+    default:
+        throw ELibMCCustomException(LIBMC_ERROR_INVALIDVARIABLETYPE, sParameterPath);
+    }
 }
 
 


### PR DESCRIPTION
Previously this would fail:

./amc_server --set main.system.myparam=1

The initalization would exit with:
Fatal initialization error: Error: INVALIDVARIABLETYPE: variable main.system.myparam is not a string variable (312)