### PR TITLE
Fix buildlist UI: include failed executions when retrieving end timestamps

### DIFF
--- a/Implementation/UI/amc_ui_module_contentitem_executionlist.cpp
+++ b/Implementation/UI/amc_ui_module_contentitem_executionlist.cpp
@@ -262,7 +262,7 @@ void CUIModule_ContentExecutionList::addLegacyContentToJSON(CJSONWriter& writer,
 
 		LibMCData::eBuildJobExecutionStatus status = pExecution->GetStatus();
 		std::string sStatusString = pExecution->GetStatusString();
-		bool bHasEndTime = (status == LibMCData::eBuildJobExecutionStatus::Finished);
+		bool bHasEndTime = (status == LibMCData::eBuildJobExecutionStatus::Finished) || (status == LibMCData::eBuildJobExecutionStatus::Failed);
 
 		uint64_t nStartTimeStamp = pExecution->GetStartTimeStampInMicroseconds();
 		uint64_t nEndTimeStamp = 0;


### PR DESCRIPTION
Now also failed/aborted builds will show their completion time in the execution list.
Before the UI would show end time stamp as a formatted version of unix timestamp 0.