### PR TITLE
Auto-rebuild client artifact when source hash is outdated

### DIFF
--- a/build_clean_linux64.sh
+++ b/build_clean_linux64.sh
@@ -86,11 +86,21 @@ echo "client dir hash: $CLIENTDIRHASH"
 CLIENTDISTHASH=$(<"$basepath/Artifacts/clientdist/_githash_client.txt")
 echo "client dist hash: $CLIENTDISTHASH"
 
-#if test $CLIENTDISTHASH != $CLIENTDIRHASH
-#then
-#	echo "Invalid client hash! Please rebuild client!"
-#	exit 1
-#fi
+if test "$CLIENTDISTHASH" != "$CLIENTDIRHASH"
+then
+	echo ""
+	echo "Client artifact is outdated — rebuilding automatically..."
+	echo "  Artifact built from: $CLIENTDISTHASH"
+	echo "  Current Client source: $CLIENTDIRHASH"
+	echo ""
+	"$basepath/Artifacts/build_client_clean.sh"
+	CLIENTDISTHASH=$(<"$basepath/Artifacts/clientdist/_githash_client.txt")
+	if test "$CLIENTDISTHASH" != "$CLIENTDIRHASH"
+	then
+		echo "ERROR: Client rebuild did not produce matching hash!"
+		exit 1
+	fi
+fi
 
 cd "$basepath"
 


### PR DESCRIPTION
Replace commented-out hash mismatch check in build_clean_linux64.sh with an automatic invocation of Artifacts/build_client_clean.sh when the pre-built client artifact doesn't match the Client/ source tree.

Eliminates the manual two-step rebuild workflow and ensures the client is always up to date after committing Client/ source changes.

However, the double-commit workflow remains: the automatic rebuild produces new artifacts that should be committed